### PR TITLE
NetFramework4.8.1 Migration

### DIFF
--- a/src/MachinaBridge.sln
+++ b/src/MachinaBridge.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.4.33110.190
+# Visual Studio Version 18
+VisualStudioVersion = 18.6.11806.211 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MachinaBridge", "MachinaBridge\MachinaBridge.csproj", "{B0FF475C-DA83-4F44-BE01-EBA40E639C7D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Machina", "..\..\Machina.NET\src\Machina\Machina.csproj", "{15951838-F9D6-4988-A103-B7C72BFE81A2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MachinaGrasshopper", "..\..\Machina-Grasshopper\src\MachinaGrasshopper\MachinaGrasshopper.csproj", "{855276EF-2C05-0C23-64CA-411A35DFDAE0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +53,22 @@ Global
 		{15951838-F9D6-4988-A103-B7C72BFE81A2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{15951838-F9D6-4988-A103-B7C72BFE81A2}.Release|x64.ActiveCfg = Release|x64
 		{15951838-F9D6-4988-A103-B7C72BFE81A2}.Release|x64.Build.0 = Release|x64
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Debug|x64.Build.0 = Debug|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Debug32|Any CPU.ActiveCfg = Debug|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Debug32|Any CPU.Build.0 = Debug|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Debug32|x64.ActiveCfg = Debug|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Debug32|x64.Build.0 = Debug|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Debug64|Any CPU.ActiveCfg = Debug|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Debug64|Any CPU.Build.0 = Debug|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Debug64|x64.ActiveCfg = Debug|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Debug64|x64.Build.0 = Debug|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Release|x64.ActiveCfg = Release|Any CPU
+		{855276EF-2C05-0C23-64CA-411A35DFDAE0}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/MachinaBridge/App.config
+++ b/src/MachinaBridge/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
     </startup>
 </configuration>

--- a/src/MachinaBridge/MachinaBridge.csproj
+++ b/src/MachinaBridge/MachinaBridge.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MachinaBridge</RootNamespace>
     <AssemblyName>MachinaBridge</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/src/MachinaBridge/MachinaBridge.csproj
+++ b/src/MachinaBridge/MachinaBridge.csproj
@@ -43,6 +43,9 @@
       <HintPath>..\packages\System.Windows.Interactivity.WPF.2.0.20525\lib\net40\Microsoft.Expression.Interactions.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />

--- a/src/MachinaBridge/MainWindow.xaml.cs
+++ b/src/MachinaBridge/MainWindow.xaml.cs
@@ -588,6 +588,18 @@ namespace MachinaBridge
             {
                 string[] instructions = Machina.Utilities.Parsing.SplitStatements(code, ';', "//");
 
+                bool hasSyncCurrent = instructions.Any(ins =>
+                {
+                    string[] parsed = Machina.Utilities.Parsing.ParseStatement(ins);
+                    return parsed != null && parsed.Length > 0 && parsed[0] == "SyncCurrent";
+                });
+
+                if (hasSyncCurrent && instructions.Length > 1)
+                {
+                    Logger.Error("SyncCurrent() must be sent alone in its own batch.");
+                    return;
+                }
+
                 foreach (var ins in instructions)
                 {
                     ExecuteStatement(ins);

--- a/src/MachinaBridge/MainWindow.xaml.cs
+++ b/src/MachinaBridge/MainWindow.xaml.cs
@@ -588,18 +588,6 @@ namespace MachinaBridge
             {
                 string[] instructions = Machina.Utilities.Parsing.SplitStatements(code, ';', "//");
 
-                bool hasSyncCurrent = instructions.Any(ins =>
-                {
-                    string[] parsed = Machina.Utilities.Parsing.ParseStatement(ins);
-                    return parsed != null && parsed.Length > 0 && parsed[0] == "SyncCurrent";
-                });
-
-                if (hasSyncCurrent && instructions.Length > 1)
-                {
-                    Logger.Error("SyncCurrent() must be sent alone in its own batch.");
-                    return;
-                }
-
                 foreach (var ins in instructions)
                 {
                     ExecuteStatement(ins);

--- a/src/MachinaBridge/Properties/Resources.Designer.cs
+++ b/src/MachinaBridge/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace MachinaBridge.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/MachinaBridge/Properties/Settings.Designer.cs
+++ b/src/MachinaBridge/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace MachinaBridge.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.14.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/src/MachinaBridge/packages.config
+++ b/src/MachinaBridge/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net481" />
   <package id="System.Windows.Interactivity.WPF" version="2.0.20525" targetFramework="net461" />
   <package id="WebSocketSharp-NonPreRelease" version="1.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
# Summary

This pull request updates the MachinaBridge project to target a newer .NET Framework version and adds a new dependency. The most important changes are grouped below:

## Framework Upgrade

* Updated the target .NET Framework from 4.6.1 to 4.8.1 in both `App.config` and `MachinaBridge.csproj` 

**Dependency Management:**
* Added `Newtonsoft.Json` version 13.0.4 as a dependency in `packages.config` and referenced it in `MachinaBridge.csproj` to enable JSON serialization/deserialization features.

## Migration Scope

The project was upgraded to .NetFramework4.8.1 to prevent breaking changes with dependencies. 

The bridge is a communication server that mainly handles class serialization from Json. Full migration to .Net8.0 may not be necessary at the time of this pull request.

## Tests
The code is tested in Rhino 8 with .Net8.0 Runtime and the new Machina-Bridge.
Tests were successful and without noticable difference from the .NetFramework4.6.0 version.
Tests were conducted on a UR10e robot and ABB robot studio simulation environments.